### PR TITLE
add changes to calibu to allow setting x and y grid spacing independently

### DIFF
--- a/applications/calib/main.cpp
+++ b/applications/calib/main.cpp
@@ -228,12 +228,8 @@ int main( int argc, char** argv)
   conic_finder.Params().conic_min_aspect = 0.2;
 
   if ((grid_spacing_x == 0) && (grid_spacing_y == 0)) {
-    std::cerr << "Starting target with grid_spacing = " << grid_spacing;
     grid_spacing_x = grid_spacing;
     grid_spacing_y = grid_spacing;
-  } else {
-    std::cerr << "Starting target with grid_spacing_x = " << grid_spacing_x
-        << ", and grid_spacing_y = " << grid_spacing_y;
   }
   TargetGridDot target( grid_spacing_x, grid_spacing_y, grid_size, grid_seed );
 

--- a/include/calibu/target/TargetGridDot.h
+++ b/include/calibu/target/TargetGridDot.h
@@ -69,7 +69,8 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 
     TargetGridDot(double grid_spacing, Eigen::Vector2i grid_size, uint32_t seed = 71);
-    TargetGridDot(double grid_spacing, const Eigen::MatrixXi& grid);
+
+    TargetGridDot(double grid_spacing_x, double grid_spacing_y, Eigen::Vector2i grid_size, uint32_t seed = 71);
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -99,7 +100,7 @@ public:
     inline double CircleRadius() const
     {
         // TODO: Load this from eps or something.
-        return grid_spacing / 10.0;
+        return grid_spacing_x / 10.0;
     }
 
     inline const std::vector<Eigen::Vector2d,
@@ -156,7 +157,8 @@ public:
     std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > tpts3d;
   std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > codepts3d;
 
-    double grid_spacing;
+    double grid_spacing_x;
+    double grid_spacing_y;
     Eigen::Vector2i grid_size;
     std::array<Eigen::MatrixXi,4> PG;
 

--- a/src/target/TargetGridDot.cpp
+++ b/src/target/TargetGridDot.cpp
@@ -31,7 +31,7 @@
 namespace calibu {
 
 TargetGridDot::TargetGridDot(double grid_spacing, Eigen::Vector2i grid_size, uint32_t seed)
-    : grid_spacing(grid_spacing), grid_size(grid_size)
+    : grid_spacing_x(grid_spacing), grid_spacing_y(grid_spacing), grid_size(grid_size)
 {
     // Create binary pattern (and rotated pattern) from seed
     PG = MakePatternGroup(grid_size(1), grid_size(0), seed);
@@ -54,15 +54,15 @@ void TargetGridDot::Init() {
   for(int r=0; r< grid_size(1); ++r) {
     for(int c=0; c< grid_size(0); ++c) {
       Eigen::Vector2i p = Eigen::Vector2i(c,r);
-      tpts2d[r*grid_size(0)+c] = grid_spacing * Eigen::Vector2d(p(0), p(1));
-      tpts3d[r*grid_size(0)+c] = grid_spacing * Eigen::Vector3d(p(0), p(1), 0);
+            tpts2d[r*grid_size(0)+c] = Eigen::Vector2d(grid_spacing_x * p(0), grid_spacing_y * p(1));
+            tpts3d[r*grid_size(0)+c] = Eigen::Vector3d(grid_spacing_x * p(0), grid_spacing_y * p(1), 0);
     }
   }
 
   // create binary pattern coords
   codepts3d.resize( 8 );
-  double r = grid_spacing*(grid_size(1)+2.5);
-  double dx =  (grid_spacing*(grid_size(0)-1))/8;
+  double r = grid_spacing_y * (grid_size(1)+2.5);
+  double dx =  (grid_spacing_x * (grid_size(0)-1))/8;
   Eigen::Vector3d base( dx/2.0, 0, 0 );
   for( int c = 0; c < 8; c++ ){
     codepts3d[c] = base + Eigen::Vector3d( dx*c, r, 0 );
@@ -594,8 +594,8 @@ void TargetGridDot::SaveEPS(
     const double border = 3*rad1;
     const Eigen::Vector2d border2d(border,border);
     const Eigen::Vector2d max_pts(
-            pts_per_unit * ((M.cols()-1) * grid_spacing + 2*border),
-            pts_per_unit * ((M.rows()-1) * grid_spacing + 2*border)
+            pts_per_unit * ((M.cols()-1) * grid_spacing_x + 2*border),
+            pts_per_unit * ((M.rows()-1) * grid_spacing_y + 2*border)
             );
 
     std::ofstream f;
@@ -612,7 +612,8 @@ void TargetGridDot::SaveEPS(
     for( int r=0; r<M.rows(); ++r ) {
         for( int c=0; c<M.cols(); ++c) {
             const double rad_pts = pts_per_unit * ((M(r,c) == 1) ? rad1 : rad0);
-            const Eigen::Vector2d p_pts = pts_per_unit* (offset + border2d + grid_spacing * Eigen::Vector2d(c,r));
+            const Eigen::Vector2d p_pts = pts_per_unit* (offset + border2d
+                + Eigen::Vector2d(grid_spacing_x * c,  grid_spacing_y * r));
             f << p_pts[0] << " " << max_pts[1] - p_pts[1] << " "
                 << rad_pts << " 0 360 arc closepath" << std::endl
                 << "0.0 setgray fill" << std::endl
@@ -621,8 +622,8 @@ void TargetGridDot::SaveEPS(
     }
 
     // output the binary code -- blank if id == 0, which is the default
-    double r = grid_spacing*( M.rows()+2.5 );
-    double dx =  (grid_spacing*(M.cols()-1))/8;
+    double r = grid_spacing_x*( M.rows()+2.5 );
+    double dx =  (grid_spacing_y*(M.cols()-1))/8;
     double hw = (pts_per_unit*dx)/2;
     Eigen::Vector2d base( dx/2.0, 0 );
     for( int c = 0; c < 8; c++ ){

--- a/src/target/TargetGridDot.cpp
+++ b/src/target/TargetGridDot.cpp
@@ -54,8 +54,8 @@ void TargetGridDot::Init() {
   for(int r=0; r< grid_size(1); ++r) {
     for(int c=0; c< grid_size(0); ++c) {
       Eigen::Vector2i p = Eigen::Vector2i(c,r);
-            tpts2d[r*grid_size(0)+c] = Eigen::Vector2d(grid_spacing_x * p(0), grid_spacing_y * p(1));
-            tpts3d[r*grid_size(0)+c] = Eigen::Vector3d(grid_spacing_x * p(0), grid_spacing_y * p(1), 0);
+      tpts2d[r*grid_size(0)+c] = Eigen::Vector2d(grid_spacing_x * p(0), grid_spacing_y * p(1));
+      tpts3d[r*grid_size(0)+c] = Eigen::Vector3d(grid_spacing_x * p(0), grid_spacing_y * p(1), 0);
     }
   }
 


### PR DESCRIPTION
This is a pr pushed up stream to allow x and y spacing independently.

We saw that on some printers the x and y spacing is not equal (i.e., the pattern gets slightly stretched in one direction).

https://github.com/Trailmix/RedwoodInternal/pull/1868