### PR TITLE
Header included and CMakeLists changed to prevent compilation errors

### DIFF
--- a/applications/calib/CMakeLists.txt
+++ b/applications/calib/CMakeLists.txt
@@ -16,7 +16,7 @@ set(NO_OPENCV_GPU TRUE)
 find_package( OpenCV QUIET )
 
 option(BUILD_CALIBGRID OFF "Toggle build calibgrid.")
-if( Pangolin_FOUND AND Ceres_FOUND AND OpenCV2_FOUND AND BUILD_CALIBGRID)
+if( Pangolin_FOUND AND Ceres_FOUND AND OpenCV_FOUND AND BUILD_CALIBGRID)
     add_executable( calibgrid main.cpp )
     target_link_libraries( calibgrid ${CERES_LIBRARIES} )
     target_link_libraries( calibgrid ${Pangolin_LIBRARIES} )

--- a/applications/calib/main.cpp
+++ b/applications/calib/main.cpp
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <memory>
 
 #include <pangolin/pangolin.h>


### PR DESCRIPTION
Include unistd to prevent undeclared identifier of function sleep.
Variable OpenCV2_FOUND changed for OpenCV_FOUND
