### PR TITLE
Added find_package miniglog to calib-hal.

### DIFF
--- a/applications/calib-hal/CMakeLists.txt
+++ b/applications/calib-hal/CMakeLists.txt
@@ -1,15 +1,17 @@
-#https://github.com/gwu-robotics/Calibu
+#https://github.com/arpg/Calibu
 find_package( Calibu 0.1 REQUIRED )
 include_directories( ${Calibu_INCLUDE_DIRS} )
 
-find_package( PbMsgs )
+#https://github.com/arpg/miniglog
+find_package( MINIGLOG )
 
 # git://github.com/stevenlovegrove/Pangolin.git
 find_package( Pangolin 0.1 QUIET )
 include_directories( ${Pangolin_INCLUDE_DIRS} )
 
-#https://github.com/gwu-robotics/HAL
+#https://github.com/arpg/HAL
 find_package( HAL 0.1 QUIET )
+find_package( PbMsgs )
 include_directories( ${HAL_INCLUDE_DIRS} )
 
 # git clone https://ceres-solver.googlesource.com/ceres-solver


### PR DESCRIPTION
It breaks for non CoreDev users if not added.
