### PR TITLE
Rotation of pattern fixed again

### DIFF
--- a/src/target/TargetGridDot.cpp
+++ b/src/target/TargetGridDot.cpp
@@ -587,7 +587,7 @@ void TargetGridDot::SaveEPS(
         unsigned char id
         ) const
 {
-    Eigen::MatrixXi M = GetBinaryPattern(1);
+    Eigen::MatrixXi M = GetBinaryPattern(0);
 
     const double border = 3*rad1;
     const Eigen::Vector2d border2d(border,border);
@@ -598,14 +598,13 @@ void TargetGridDot::SaveEPS(
 
     std::ofstream f;
     f.open(filename.c_str());
-    f << "%!PS-Adobe EPSF-3.0" << std::endl;
+    f << "%!PS-Adobe-3.0 EPSF-3.0" << std::endl;
     f << "%%Creator: CalibuCalibrationTarget" << std::endl;
     f << "%%Title: Calibration Target" << std::endl;
     f << "%%Origin: 0 0" << std::endl;
     // usletter BoundingBox is 0, 0, 612, 792
     f << "%%BoundingBox: 0 0 " << max_pts[0] << " " << max_pts[1] << std::endl;
     f << std::endl;
-    f << "270 rotate 0 " << -max_pts[0] << " 0 translate" << std::endl;
 
     for( int r=0; r<M.rows(); ++r ) {
         for( int c=0; c<M.cols(); ++c) {


### PR DESCRIPTION
The patterns are saved with the correct orientation and paper size when written into EPS files.
