### PR TITLE
Ceres update

### DIFF
--- a/applications/calib-hal/CMakeLists.txt
+++ b/applications/calib-hal/CMakeLists.txt
@@ -22,6 +22,9 @@ include_directories( ${CERES_INCLUDES} )
 find_package( OpenCV2 QUIET )
 include_directories( ${OpenCV2_INCLUDES} )
 
+find_package( CVARS )
+include_directories( ${CVARS_INCLUDE_DIR} )
+
 # This depends on HAL, which in turns depends on Calibu, so we disable this by default
 set(BUILD_CALIBGRID_HAL OFF CACHE BOOL "To build or not build calibgrid-hal")
 

--- a/applications/calib-hal/main.cpp
+++ b/applications/calib-hal/main.cpp
@@ -381,7 +381,7 @@ int main(int argc, char** argv)
     pangolin::RegisterKeyPressCallback(']', [&](){calibrator.Stop();} );
 
     bool step = false;
-    pangolin::RegisterKeyPressCallback(pangolin::PANGO_SPECIAL+ GLUT_KEY_RIGHT, [&](){step = true;} );
+    pangolin::RegisterKeyPressCallback(pangolin::PANGO_SPECIAL+ pangolin::PANGO_KEY_RIGHT, [&](){step = true;} );
     pangolin::RegisterKeyPressCallback(' ', [&](){run = !run;} );
 
     pangolin::RegisterKeyPressCallback('r', [&](){calibrator.PrintResults();} );

--- a/include/calibu/calib/Calibrator.h
+++ b/include/calibu/calib/Calibrator.h
@@ -86,8 +86,6 @@ public:
         m_solver_options.update_state_every_iteration = true;
         m_solver_options.max_num_iterations = 10;
         
-        m_termination_type = ceres::DID_NOT_RUN;
-
         Clear();
     }
     
@@ -257,9 +255,7 @@ public:
     /// Return true if one of the tolerance criteria is reached.
     bool ReachedTolerance()
     {
-    	return ((m_termination_type == ceres::FUNCTION_TOLERANCE) ||
-		(m_termination_type == ceres::PARAMETER_TOLERANCE) ||
-		(m_termination_type == ceres::GRADIENT_TOLERANCE));
+      return ((m_termination_type == ceres::CONVERGENCE));
     }
 
 
@@ -399,7 +395,7 @@ protected:
     bool m_should_run;
     bool m_running;
     bool m_fix_intrinsics;
-    ceres::SolverTerminationType m_termination_type;
+    ceres::TerminationType m_termination_type;
     
     std::vector< std::unique_ptr<Sophus::SE3d> > m_T_kw;
     std::vector< std::unique_ptr<CameraAndPose> > m_camera;


### PR DESCRIPTION
This updates Calibrator.h to use latest ceres enumerations for stopping criteria making calib-hal compatible with the new ceres.