### PR TITLE
Fix/numparams

### DIFF
--- a/src/cam/StereoRectify.cpp
+++ b/src/cam/StereoRectify.cpp
@@ -83,7 +83,8 @@ std::shared_ptr<calibu::Rig<double>> CreateScanlineRectifiedLookupAndCameras(con
 
     // Setup new camera
     Eigen::Vector2i size_;
-    Eigen::VectorXd params_(calibu::LinearCamera<double>::NumParams);
+    Eigen::VectorXd params_(1);
+    params_.resize(calibu::LinearCamera<double>::NumParams);
     size_ << cam_left->Width(), cam_left->Height();
     params_ << fu, fv, u0, v0;
 

--- a/src/cam/StereoRectify.cpp
+++ b/src/cam/StereoRectify.cpp
@@ -83,8 +83,9 @@ std::shared_ptr<calibu::Rig<double>> CreateScanlineRectifiedLookupAndCameras(con
 
     // Setup new camera
     Eigen::Vector2i size_;
-    Eigen::VectorXd params_(1);
-    params_.resize(calibu::LinearCamera<double>::NumParams);
+    //Eigen::VectorXd params_(1);
+    //params_.resize(calibu::LinearCamera<double>::NumParams);
+    Eigen::Matrix<double,1, calibu::LinearCamera<double>::NumParams> params_;
     size_ << cam_left->Width(), cam_left->Height();
     params_ << fu, fv, u0, v0;
 

--- a/src/cam/StereoRectify.cpp
+++ b/src/cam/StereoRectify.cpp
@@ -83,8 +83,6 @@ std::shared_ptr<calibu::Rig<double>> CreateScanlineRectifiedLookupAndCameras(con
 
     // Setup new camera
     Eigen::Vector2i size_;
-    //Eigen::VectorXd params_(1);
-    //params_.resize(calibu::LinearCamera<double>::NumParams);
     Eigen::Matrix<double,1, calibu::LinearCamera<double>::NumParams> params_;
     size_ << cam_left->Width(), cam_left->Height();
     params_ << fu, fv, u0, v0;


### PR DESCRIPTION
Addresses Issue HAL#130

Issue caused by passing constexpr _NumParams_ from header only class. Solution is to template Eigen::Matrix class instead of constructing Eigen::VectorXd. 