### PR TITLE
fixed pixel bounds check bug in CreateLookupTable function

### DIFF
--- a/src/cam/rectify_crtp.cpp
+++ b/src/cam/rectify_crtp.cpp
@@ -123,7 +123,7 @@ namespace calibu
           u -= 1;
           su = 1.0;
         }
-        if(v == (cam_width-1)) {
+        if(v == (cam_height-1)) {
           v -= 1;
           sv = 1.0;
         }


### PR DESCRIPTION
There was a bug CreateLookupTable function, which is used by the HAL Undistort Camera Driver. It was using image-width to clamp both horizontal and vertical pixel coordinates. This fix instead uses image-height to clamp the vertical component.